### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,13 @@ Presser v0.1
     :target: https://coveralls.io/r/ladyrassilon/presser?branch=master
 .. image:: https://travis-ci.org/ladyrassilon/presser.svg?branch=master
     :target: https://travis-ci.org/ladyrassilon/presser
-.. image:: https://pypip.in/version/Presser/badge.svg
+.. image:: https://img.shields.io/pypi/v/Presser.svg
     :target: https://pypi.python.org/pypi/Presser/
     :alt: Latest Version
-.. image:: https://pypip.in/implementation/Presser/badge.svg
+.. image:: https://img.shields.io/pypi/implementation/Presser.svg
     :target: https://pypi.python.org/pypi/Presser/
     :alt: Supported Python implementations
-.. image:: https://pypip.in/status/Presser/badge.svg
+.. image:: https://img.shields.io/pypi/status/Presser.svg
     :target: https://pypi.python.org/pypi/Presser/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20presser))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `presser`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.